### PR TITLE
create shared memory class for door

### DIFF
--- a/src/door_shared_memory.cpp
+++ b/src/door_shared_memory.cpp
@@ -1,0 +1,26 @@
+#include "door_shared_memory.h"
+
+DoorSharedMemory::DoorSharedMemory(std::string sharedMemoryName) {
+    m_sharedMemoryName_ = sharedMemoryName.c_str();
+}
+
+DoorSharedMemory::~DoorSharedMemory() {
+}
+
+std::string
+DoorSharedMemory::init() {
+    shared_memory_object shm(open_only, m_sharedMemoryName_, read_write);
+    mapped_region region(shm, read_write);
+    void *addr = region.get_address();
+    m_sharedMemoryBuffer = static_cast<SharedMemoryBuffer*>(addr);
+
+    try {
+        m_sharedMemoryBuffer->reader.wait();
+        // Do sth
+        m_sahredMemoryBuffer->writer.post();
+        return "hoge";
+    } catch (interprocess_exception& e) {
+        std::cout << e.what() << std::endl;
+    }
+}
+

--- a/src/door_shared_memory.cpp
+++ b/src/door_shared_memory.cpp
@@ -17,7 +17,7 @@ DoorSharedMemory::init() {
     try {
         m_sharedMemoryBuffer->reader.wait();
         // Do sth
-        m_sahredMemoryBuffer->writer.post();
+        m_sharedMemoryBuffer->writer.post();
         return "hoge";
     } catch (interprocess_exception& e) {
         std::cout << e.what() << std::endl;

--- a/src/door_shared_memory.h
+++ b/src/door_shared_memory.h
@@ -26,7 +26,7 @@ public:
 private:
     SharedMemoryBuffer *m_sharedMemoryBuffer;
     const char* m_sharedMemoryName_;
-}
+};
 
 
 #endif

--- a/src/door_shared_memory.h
+++ b/src/door_shared_memory.h
@@ -1,0 +1,33 @@
+#ifndef DOOR_SHARED_MEMORY_H_
+#define DOOR_SHARED_MEMORY_H_
+
+#include <iostream>
+#include <string>
+
+#include <boost/interprocess/shared_memory_object.hpp>
+#include <boost/interprocess/mapped_region.hpp>
+#include <boost/interprocess/sync/interprocess_semaphore.hpp>
+
+using namespace boost::interprocess;
+
+class DoorSharedMemory
+{
+    struct SharedMemoryBuffer {
+        SharedMemoryBuffer(): writer(1), reader(0) {}
+        interprocess_semaphore writer, reader;
+        char doorData[100];
+    };
+
+public:
+    DoorSharedMemory(std::string);
+    ~DoorSharedMemory();
+    std::string init();
+
+private:
+    SharedMemoryBuffer *m_sharedMemoryBuffer;
+    const char* m_sharedMemoryName_;
+}
+
+
+#endif
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,21 +4,21 @@
 #include "unix_client.h"
 #include "shared_memory.h"
 
-std::string getShmKey(int);
-
 int
 main() {
+    // this shmKey for application to know the shared memory name, which connected client and server
+    std::string baseShmKey = "shmKey0000";
+
     // run socket communication
     UnixClient client = UnixClient();
     client.run();
-    std::string shmKey = client.getRecievedKey();
-    std::cout << shmKey << std::endl;
+    std::string clientShmKey = client.getRecievedKey();
+    std::cout << clientShmKey << std::endl;
 
-    // shared memory
-    SharedMemory *shm = new SharedMemory(shmKey);
-    std::string shmAppKey = shm->init();
 
-    delete shm;
+    // create shared memory, which are referd by application to know the clientShmKey
+    SharedMemory *shm = new SharedMemory(baseShmKey);
+    shm->initWrite(clientShmKey);
     return 0;
 };
 

--- a/src/shared_memory.cpp
+++ b/src/shared_memory.cpp
@@ -32,7 +32,7 @@ SharedMemory::initRead() {
 }
 
 bool
-SharedMemory::initWrite() {
+SharedMemory::initWrite(std::string shmKeyName) {
     shared_memory_object shm(open_or_create, m_sharedMemoryName_, read_write);
     shm.truncate(sizeof(SharedMemoryBuffer));
     mapped_region region(shm, read_write);
@@ -42,7 +42,7 @@ SharedMemory::initWrite() {
     try {
         while(true) {
             m_sharedMemoryBuffer->writer.wait();
-                strcpy(m_sharedMemoryBuffer->appShmKey, m_sharedMemoryName_);
+                strcpy(m_sharedMemoryBuffer->appShmKey, shmKeyName.c_str());
             m_sharedMemoryBuffer->reader.post();
         };
     } catch (interprocess_exception& e) {

--- a/src/shared_memory.cpp
+++ b/src/shared_memory.cpp
@@ -8,17 +8,16 @@ SharedMemory::~SharedMemory() {
     // TODO: check shared memory is alreadly deleted
     if (m_sharedMemoryBuffer != NULL) {
     }
-
 }
 
 std::string
-SharedMemory::init() {
-    std::cout << "init" << std::endl;
+SharedMemory::initRead() {
+    std::cout << "init reading" << std::endl;
     shared_memory_object shm(open_only, m_sharedMemoryName_, read_write);
     mapped_region region(shm, read_write);
     void *addr = region.get_address();
     m_sharedMemoryBuffer = static_cast<SharedMemoryBuffer*>(addr);
-    std::cout << "ready" << std::endl;
+    std::cout << sizeof(SharedMemoryBuffer) << std::endl;
 
     try {
         m_sharedMemoryBuffer->reader.wait();
@@ -31,5 +30,26 @@ SharedMemory::init() {
         std::cout << e.what() << std::endl;
     }
 }
+
+bool
+SharedMemory::initWrite() {
+    shared_memory_object shm(open_or_create, m_sharedMemoryName_, read_write);
+    shm.truncate(sizeof(SharedMemoryBuffer));
+    mapped_region region(shm, read_write);
+    void *addr = region.get_address();
+    m_sharedMemoryBuffer = new (addr) SharedMemoryBuffer;
+
+    try {
+        while(true) {
+            m_sharedMemoryBuffer->writer.wait();
+                strcpy(m_sharedMemoryBuffer->appShmKey, m_sharedMemoryName_);
+            m_sharedMemoryBuffer->reader.post();
+        };
+    } catch (interprocess_exception& e) {
+        std::cout << e.what() << std::endl;
+    }
+    return true;
+}
+
 
 

--- a/src/shared_memory.h
+++ b/src/shared_memory.h
@@ -3,8 +3,6 @@
 
 #include <iostream>
 #include <string>
-#include <stdio.h>
-#include <stdlib.h>
 
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/interprocess/mapped_region.hpp>
@@ -23,7 +21,8 @@ class SharedMemory
 public:
     SharedMemory(std::string);
     ~SharedMemory();
-    std::string init();
+    std::string initRead();
+    bool initWrite();
 
 private:
     SharedMemoryBuffer *m_sharedMemoryBuffer;

--- a/src/shared_memory.h
+++ b/src/shared_memory.h
@@ -3,6 +3,8 @@
 
 #include <iostream>
 #include <string>
+#include <stdio.h>
+#include <stdlib.h>
 
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/interprocess/mapped_region.hpp>

--- a/src/shared_memory.h
+++ b/src/shared_memory.h
@@ -22,7 +22,7 @@ public:
     SharedMemory(std::string);
     ~SharedMemory();
     std::string initRead();
-    bool initWrite();
+    bool initWrite(std::string);
 
 private:
     SharedMemoryBuffer *m_sharedMemoryBuffer;


### PR DESCRIPTION
## WHY 
in client use 3 shared memory key, which are for door, server and application. 
Shared structure will be complex, so the class shuold be separated for each usage.

## WHAT
- create writer shared memory class for door
- create reader shared memory class for application (writer side will be in door)
   - save shmkey name for door communication